### PR TITLE
Reset undo/redo history on clear and restart

### DIFF
--- a/packages/playground/src/components/TopBar.tsx
+++ b/packages/playground/src/components/TopBar.tsx
@@ -4,19 +4,17 @@ import { useEngine } from "../hooks/useEngine";
 import { useInit } from "../hooks/useInit";
 import { useJoints } from "../hooks/modules/useJoints";
 import { useLines } from "../hooks/modules/useLines";
-import { useAppDispatch } from "../hooks/useAppDispatch";
-import { clear as clearHistory } from "../slices/history";
-import { clearRegistry as clearHistoryRegistry } from "../history/registry";
+import { useHistory } from "../hooks/useHistory";
 import "./TopBar.css";
 import { HelpModal } from "./HelpModal";
 
 export function TopBar() {
-  const dispatch = useAppDispatch();
   const [helpOpen, setHelpOpen] = useState(false);
   const { isPlaying, play, pause, clear, spawnParticles } = useEngine();
   const { initState, gridJoints, setGridJoints } = useInit();
   const { removeAllJoints } = useJoints();
   const { removeAllLines } = useLines();
+  const { resetHistory } = useHistory();
 
   const handlePlayPause = () => {
     if (isPlaying) {
@@ -28,8 +26,7 @@ export function TopBar() {
 
   const handleClear = () => {
     // Reset undo/redo history
-    dispatch(clearHistory());
-    clearHistoryRegistry();
+    resetHistory();
 
     // Clear scene
     clear();
@@ -39,8 +36,7 @@ export function TopBar() {
 
   const handleReset = useCallback(() => {
     // Reset undo/redo history
-    dispatch(clearHistory());
-    clearHistoryRegistry();
+    resetHistory();
 
     // Reset joints and lines using helper methods
     removeAllJoints();
@@ -55,7 +51,7 @@ export function TopBar() {
       setTimeout(() => setGridJoints(true), 0);
     }
   }, [
-    dispatch,
+    resetHistory,
     removeAllJoints,
     removeAllLines,
     spawnParticles,

--- a/packages/playground/src/hooks/useHistory.ts
+++ b/packages/playground/src/hooks/useHistory.ts
@@ -18,6 +18,8 @@ import {
 import type { Command, HistoryContext } from "../types/history";
 import { useEngine } from "./useEngine";
 import { getCommand } from "../history/registry";
+import { clear as clearHistory } from "../slices/history";
+import { clearRegistry as clearHistoryRegistry } from "../history/registry";
 
 export function useHistory() {
   const dispatch = useAppDispatch();
@@ -118,6 +120,11 @@ export function useHistory() {
     dispatch(cancelTransactionAction());
   }, [dispatch]);
 
+  const resetHistory = useCallback(() => {
+    dispatch(clearHistory());
+    clearHistoryRegistry();
+  }, [dispatch]);
+
   return {
     canUndo,
     canRedo,
@@ -128,5 +135,6 @@ export function useHistory() {
     commitTransaction: commit,
     cancelTransaction: cancel,
     executeCommand,
+    resetHistory,
   };
 }


### PR DESCRIPTION
Reset undo/redo history when Clear and Restart actions are performed.

This ensures that after clearing or restarting the scene, the undo/redo stacks are empty, preventing users from undoing/redoing actions that occurred before the reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-34db7c4f-d162-462b-a8da-6ffa6437667f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-34db7c4f-d162-462b-a8da-6ffa6437667f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

