### PR TITLE
Move and style undo/redo buttons to topbar

### DIFF
--- a/packages/playground/src/components/ToolBar.tsx
+++ b/packages/playground/src/components/ToolBar.tsx
@@ -7,11 +7,8 @@ import {
   Hand,
   Pen,
   Hexagon,
-  Undo,
-  Redo,
 } from "lucide-react";
 import { useTools } from "../hooks/useTools";
-import { useHistory } from "../hooks/useHistory";
 
 import "./ToolBar.css";
 
@@ -27,31 +24,10 @@ export function Toolbar({ style }: { style?: React.CSSProperties }) {
     isShapeMode,
     setToolMode,
   } = useTools();
-  const { undo, redo, canUndo, canRedo } = useHistory();
 
   return (
     <div className="toolbar" style={style}>
       <div className="toolbar-content">
-        <div className="history-controls" style={{ display: "flex", gap: 8 }}>
-          <button
-            onClick={undo}
-            disabled={!canUndo}
-            className="tool-mode-button"
-            title="Undo (Cmd/Ctrl+Z)"
-          >
-            <Undo width="16" height="16" />
-            <span>Undo</span>
-          </button>
-          <button
-            onClick={redo}
-            disabled={!canRedo}
-            className="tool-mode-button"
-            title="Redo (Shift+Cmd/Ctrl+Z or Cmd/Ctrl+Y)"
-          >
-            <Redo width="16" height="16" />
-            <span>Redo</span>
-          </button>
-        </div>
         <div className="tool-mode-selector">
           <button
             onClick={() => setToolMode("interaction")}

--- a/packages/playground/src/components/TopBar.css
+++ b/packages/playground/src/components/TopBar.css
@@ -37,7 +37,10 @@
 .tool-group {
   display: flex;
   align-items: center;
-  margin-left: 24px;
+  gap: 12px;
+  margin-left: 16px; /* visual separation between control groups */
+  padding-left: 16px;
+  border-left: 1px solid rgba(255, 255, 255, 0.2);
 }
 
 .tool-mode-selector {
@@ -101,6 +104,8 @@
 .play-pause-button,
 .clear-button,
 .reset-spawn-button,
+.undo-button,
+.redo-button,
 .topbar-save-button,
 .topbar-load-button {
   display: flex;
@@ -139,6 +144,8 @@
 .play-pause-button:hover,
 .clear-button:hover,
 .reset-spawn-button:hover,
+.undo-button:hover,
+.redo-button:hover,
 .topbar-save-button:hover,
 .topbar-load-button:hover {
   background: rgba(255, 255, 255, 0.2);

--- a/packages/playground/src/components/TopBar.tsx
+++ b/packages/playground/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react";
-import { RefreshCw, Trash2, HelpCircle } from "lucide-react";
+import { RefreshCw, Trash2, HelpCircle, Undo, Redo } from "lucide-react";
 import { useEngine } from "../hooks/useEngine";
 import { useInit } from "../hooks/useInit";
 import { useJoints } from "../hooks/modules/useJoints";
@@ -14,7 +14,7 @@ export function TopBar() {
   const { initState, gridJoints, setGridJoints } = useInit();
   const { removeAllJoints } = useJoints();
   const { removeAllLines } = useLines();
-  const { resetHistory } = useHistory();
+  const { resetHistory, undo, redo, canUndo, canRedo } = useHistory();
 
   const handlePlayPause = () => {
     if (isPlaying) {
@@ -102,6 +102,27 @@ export function TopBar() {
             <RefreshCw width="12" height="12" />
             <span>Restart</span>
           </button>
+
+          <div className="tool-group">
+            <button
+              onClick={undo}
+              disabled={!canUndo}
+              className="undo-button"
+              title="Undo (Cmd/Ctrl+Z)"
+            >
+              <Undo width="12" height="12" />
+              <span>Undo</span>
+            </button>
+            <button
+              onClick={redo}
+              disabled={!canRedo}
+              className="redo-button"
+              title="Redo (Shift+Cmd/Ctrl+Z or Cmd/Ctrl+Y)"
+            >
+              <Redo width="12" height="12" />
+              <span>Redo</span>
+            </button>
+          </div>
         </div>
         <div className="topbar-right">
           <button


### PR DESCRIPTION
Move undo/redo buttons from the Toolbar to the Topbar, styled to match existing Topbar buttons and visually separated from other controls.

---
<a href="https://cursor.com/background-agent?bcId=bc-f0f6a5f1-e942-46a7-8953-e36bec982bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f0f6a5f1-e942-46a7-8953-e36bec982bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

