### PR TITLE
Default playground Fluids to PIC/FLIP

### DIFF
--- a/packages/playground/src/slices/modules/fluids.ts
+++ b/packages/playground/src/slices/modules/fluids.ts
@@ -29,7 +29,7 @@ export interface FluidsModuleState {
 
 const initialState: FluidsModuleState = {
   enabled: false,
-  method: FluidsMethod.Sph,
+  method: FluidsMethod.Picflip,
   influenceRadius: DEFAULT_FLUIDS_INFLUENCE_RADIUS,
   targetDensity: DEFAULT_FLUIDS_TARGET_DENSITY,
   pressureMultiplier: DEFAULT_FLUIDS_PRESSURE_MULTIPLIER,


### PR DESCRIPTION
## Summary

- default the playground Fluids Method control to PIC/FLIP
- keep the core library Fluids constructor defaulting to SPH
- preserve explicit method values when importing existing sessions

## Validation

- npm run type-check
- npm run build
- verified the fresh playground UI selects PIC/FLIP
- verified new Fluids().getMethod() still returns SPH in the core build