### PR TITLE
Canonicalize Party URLs and publish SEO metadata

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/cazala/party.git",
     "directory": "packages/core"
   },
-  "homepage": "https://github.com/cazala/party#readme",
+  "homepage": "https://caza.la/party/",
   "bugs": {
     "url": "https://github.com/cazala/party/issues"
   },

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -4,34 +4,35 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="any" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <title>Party - Particle system and physics engine</title>
+    <title>Party — WebGPU particle system and physics engine</title>
     <meta
       name="description"
-      content="A high-performance particle physics simulation system with interactive playground, built with TypeScript and WebGPU/CPU dual runtime support."
+      content="Party is a high-performance WebGPU particle system and physics engine for TypeScript, with a CPU fallback and an interactive playground."
     />
-    <meta name="keywords" content="party, particles, physics, engine, webgpu, canvas, creative coding, simulation" />
     <meta name="author" content="Party contributors" />
     <meta name="theme-color" content="#0b0f19" />
+    <link rel="canonical" href="https://caza.la/party/" />
 
     <meta property="og:site_name" content="Party" />
-    <meta property="og:title" content="Party — Particle system and physics engine" />
+    <meta property="og:title" content="Party — WebGPU particle system and physics engine" />
     <meta
       property="og:description"
-      content="A high-performance particle physics simulation system with interactive playground, built with TypeScript and WebGPU/CPU dual runtime support."
+      content="Party is a high-performance WebGPU particle system and physics engine for TypeScript, with a CPU fallback and an interactive playground."
     />
-    <meta property="og:image" content="/logo.png" />
+    <meta property="og:url" content="https://caza.la/party/" />
+    <meta property="og:image" content="https://caza.la/party/logo.png" />
     <meta property="og:image:width" content="512" />
     <meta property="og:image:height" content="512" />
     <meta property="og:image:alt" content="Party logo" />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="Party — Particle system and physics engine" />
+    <meta name="twitter:title" content="Party — WebGPU particle system and physics engine" />
     <meta
       name="twitter:description"
-      content="A high-performance particle physics simulation system with interactive playground, built with TypeScript and WebGPU/CPU dual runtime support."
+      content="Party is a high-performance WebGPU particle system and physics engine for TypeScript, with a CPU fallback and an interactive playground."
     />
-    <meta name="twitter:image" content="/logo.png" />
+    <meta name="twitter:image" content="https://caza.la/party/logo.png" />
     <meta name="twitter:image:alt" content="Party logo" />
   </head>
   <body>

--- a/packages/playground/public/_headers
+++ b/packages/playground/public/_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: noindex

--- a/packages/playground/public/app-sitemap.xml
+++ b/packages/playground/public/app-sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://caza.la/party/</loc>
+  </url>
+</urlset>

--- a/packages/playground/public/sitemap.xml
+++ b/packages/playground/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://caza.la/party/app-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://caza.la/party/docs/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/packages/worker/README.md
+++ b/packages/worker/README.md
@@ -1,22 +1,25 @@
 ### `worker` (Cloudflare Worker)
 
-This package deploys a **route-scoped Cloudflare Worker** that serves the Party playground at:
+This package deploys a **route-scoped Cloudflare Worker** that serves Party at its canonical URL:
 
-- **`https://caza.la/party`**
+- **`https://caza.la/party/`**
 
-It does this by **reverse-proxying** to the upstream origin:
+It reverse-proxies canonical requests to the Cloudflare Pages origin:
 
-- **`https://party.caza.la`**
+- **`https://party-playground.pages.dev`**
 
-The browser URL stays on **`caza.la/party...`** (no redirects to `*.pages.dev`, `party.caza.la`, or the upstream domain).
+The browser URL stays on **`caza.la/party...`**. Requests to the old public origin, **`https://party.caza.la/*`**, receive a permanent redirect to the equivalent canonical path. Existing `/party/...` paths are preserved, so shared playground sessions are not broken.
+
+The Pages build sends `X-Robots-Tag: noindex` to prevent the raw origin from competing in search results. The Worker removes that header from responses served through the canonical URL.
 
 ### Configuration
 
 Configured in `wrangler.toml`:
 
 - **Worker name**: `cazala-party-worker`
-- **Route**: `caza.la/party*`
-- **Upstream**: `vars.UPSTREAM_ORIGIN` (default: `https://party.caza.la`)
+- **Canonical route**: `caza.la/party*`
+- **Redirect route**: `party.caza.la/*`
+- **Upstream**: `vars.UPSTREAM_ORIGIN` (default: `https://party-playground.pages.dev`)
 - **Response header**: `x-edge-proxy: cazala-party-worker`
 
 ### Scripts
@@ -32,4 +35,3 @@ pnpm --filter worker run typecheck
 ```bash
 pnpm --filter worker run deploy
 ```
-

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -6,6 +6,26 @@ export interface Env {
 
 const EDGE_PROXY_HEADER_VALUE = "cazala-party-worker";
 const PARTY_PREFIX = "/party";
+const CANONICAL_ORIGIN = "https://caza.la";
+const ALTERNATE_HOST = "party.caza.la";
+
+function canonicalPartyPath(pathname: string): string {
+  if (pathname === PARTY_PREFIX || pathname === "/") {
+    return `${PARTY_PREFIX}/`;
+  }
+
+  if (pathname.startsWith(`${PARTY_PREFIX}/`)) {
+    return pathname;
+  }
+
+  return `${PARTY_PREFIX}${pathname}`;
+}
+
+function canonicalPartyUrl(url: URL): URL {
+  const canonicalUrl = new URL(canonicalPartyPath(url.pathname), CANONICAL_ORIGIN);
+  canonicalUrl.search = url.search;
+  return canonicalUrl;
+}
 
 function isBodyAllowed(method: string): boolean {
   // Cloudflare's fetch follows standard semantics: GET/HEAD should not include a body.
@@ -45,6 +65,17 @@ export default {
     const url = new URL(request.url);
 
     // 1) Routing rules
+    if (url.hostname === ALTERNATE_HOST) {
+      return new Response(null, {
+        status: 301,
+        headers: withEdgeHeader(
+          new Headers({
+            Location: canonicalPartyUrl(url).toString(),
+          }),
+        ),
+      });
+    }
+
     if (url.pathname === PARTY_PREFIX) {
       // Trailing slash normalization (same-host, same-scheme).
       return new Response(null, {
@@ -109,6 +140,8 @@ export default {
     // 3) Caching (keep it simple)
     // Only add long-lived caching if upstream didn't provide it.
     const responseHeaders = withEdgeHeader(upstreamResponse.headers);
+    // The Pages origin is deliberately noindex. Only the canonical proxy is indexable.
+    responseHeaders.delete("x-robots-tag");
     if (looksLikeAssetPath(upstreamPath) && !responseHeaders.has("cache-control")) {
       responseHeaders.set("Cache-Control", "public, max-age=31536000, immutable");
     }
@@ -120,4 +153,3 @@ export default {
     });
   },
 };
-

--- a/packages/worker/wrangler.toml
+++ b/packages/worker/wrangler.toml
@@ -3,9 +3,9 @@ main = "src/index.ts"
 compatibility_date = "2025-12-30"
 
 routes = [
-  { pattern = "caza.la/party*", zone_name = "caza.la" }
+  { pattern = "caza.la/party*", zone_name = "caza.la" },
+  { pattern = "party.caza.la/*", zone_name = "caza.la" }
 ]
 
 [vars]
-UPSTREAM_ORIGIN = "https://party.caza.la"
-
+UPSTREAM_ORIGIN = "https://party-playground.pages.dev"


### PR DESCRIPTION
## Summary

- declare `https://caza.la/party/` as the canonical homepage and use absolute canonical social metadata
- publish a sitemap index for the playground and generated documentation
- mark the raw Cloudflare Pages origin `noindex`, while keeping canonical proxy responses indexable
- permanently redirect `party.caza.la` paths to their `caza.la/party` equivalents without breaking shared sessions or query strings
- point the core package homepage at the canonical website

## Redirect behavior

| Source | Destination |
| --- | --- |
| `party.caza.la/` | `caza.la/party/` |
| `party.caza.la/docs/...` | `caza.la/party/docs/...` |
| `party.caza.la/party/<session>` | `caza.la/party/<session>` |

The Worker now proxies canonical requests directly to `party-playground.pages.dev`, avoiding a redirect loop after `party.caza.la` becomes redirect-only.

## Validation

- `VITE_PUBLIC_BASE=/party/ npm run build`
- `npx pnpm@9.15.9 --filter worker run typecheck`
- `xmllint --noout` for the playground sitemap, sitemap index, and generated docs sitemap
- Worker assertions for root, docs, shared-session, query-string, upstream path, and `X-Robots-Tag` behavior
- `npx pnpm@9.15.9 --filter worker exec wrangler deploy --dry-run`
